### PR TITLE
Add ability to define who can add proposals

### DIFF
--- a/sputnikdao/Cargo.lock
+++ b/sputnikdao/Cargo.lock
@@ -7,6 +7,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,10 +167,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+
+[[package]]
+name = "memchr"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memory_units"
@@ -356,6 +377,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+ "thread_local",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +463,7 @@ version = "0.1.0"
 dependencies = [
  "near-lib",
  "near-sdk",
+ "regex",
 ]
 
 [[package]]
@@ -435,6 +475,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]

--- a/sputnikdao/Cargo.toml
+++ b/sputnikdao/Cargo.toml
@@ -20,3 +20,4 @@ overflow-checks = true
 [dependencies]
 near-sdk = "2.0.0"
 near-lib = { path = "../near-lib-rs" }
+regex = "1"

--- a/sputnikdao/src/lib.rs
+++ b/sputnikdao/src/lib.rs
@@ -5,6 +5,7 @@ use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::{UnorderedSet, Vector};
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::{env, near_bindgen, AccountId, Balance, Promise};
+use regex::Regex;
 
 #[global_allocator]
 static ALLOC: near_sdk::wee_alloc::WeeAlloc<'_> = near_sdk::wee_alloc::WeeAlloc::INIT;
@@ -97,6 +98,7 @@ pub enum ProposalKind {
     ChangeBond { bond: WrappedBalance },
     ChangePolicy { policy: Vec<PolicyItem> },
     ChangePurpose { purpose: String },
+    ChangeMode { mode: ProposalMode },
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
@@ -145,12 +147,40 @@ impl Proposal {
     }
 }
 
+/// Information for a new proposal.
 #[derive(Serialize, Deserialize)]
 #[serde(crate = "near_sdk::serde")]
 pub struct ProposalInput {
     target: AccountId,
     description: String,
     kind: ProposalKind,
+}
+
+/// Define who can create proposals.
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone)]
+#[serde(crate = "near_sdk::serde", tag = "type")]
+pub enum ProposalMode {
+    /// Anyone can create a proposal.
+    Open,
+    /// Limited to council members.
+    Council,
+    /// Limited to specific set of account ids.
+    Accounts(Vec<AccountId>),
+    /// Limited to account id regex pattern.
+    Pattern(String),
+}
+
+impl ProposalMode {
+    pub fn is_allowed(&self, council: &[AccountId]) -> bool {
+        match self {
+            ProposalMode::Open => true,
+            ProposalMode::Council => council.contains(&env::predecessor_account_id()),
+            ProposalMode::Accounts(accounts) => accounts.contains(&env::predecessor_account_id()),
+            ProposalMode::Pattern(pattern) => Regex::new(pattern)
+                .expect("Invalid pattern")
+                .is_match(&env::predecessor_account_id()),
+        }
+    }
 }
 
 #[near_bindgen]
@@ -163,6 +193,7 @@ pub struct SputnikDAO {
     policy: Vec<PolicyItem>,
     council: UnorderedSet<AccountId>,
     proposals: Vector<Proposal>,
+    mode: ProposalMode,
 }
 
 impl Default for SputnikDAO {
@@ -194,6 +225,7 @@ impl SputnikDAO {
             }],
             council: UnorderedSet::new(b"c".to_vec()),
             proposals: Vector::new(b"p".to_vec()),
+            mode: ProposalMode::Open,
         };
         for account_id in council {
             dao.council.insert(&account_id);
@@ -203,6 +235,7 @@ impl SputnikDAO {
 
     #[payable]
     pub fn add_proposal(&mut self, proposal: ProposalInput) -> u64 {
+        assert!(self.mode.is_allowed(&self.council.to_vec()));
         // TODO: add also extra storage cost for the proposal itself.
         assert!(env::attached_deposit() >= self.bond, "Not enough deposit");
         assert!(
@@ -312,6 +345,10 @@ impl SputnikDAO {
         self.purpose.clone()
     }
 
+    pub fn get_mode(&self) -> ProposalMode {
+        self.mode.clone()
+    }
+
     pub fn vote(&mut self, id: u64, vote: Vote) {
         assert!(
             self.council.contains(&env::predecessor_account_id()),
@@ -383,6 +420,9 @@ impl SputnikDAO {
                     }
                     ProposalKind::ChangePurpose { ref purpose } => {
                         self.purpose = purpose.clone();
+                    }
+                    ProposalKind::ChangeMode { ref mode } => {
+                        self.mode = mode.clone();
                     }
                 };
             }
@@ -723,5 +763,20 @@ mod tests {
                 ],
             },
         });
+    }
+
+    #[test]
+    fn test_proposal_mode() {
+        testing_env!(VMContextBuilder::new()
+            .predecessor_account_id(accounts(2))
+            .finish());
+        assert!(ProposalMode::Open.is_allowed(&[]));
+        assert!(!ProposalMode::Council.is_allowed(&[]));
+        assert!(!ProposalMode::Council.is_allowed(&[accounts(0)]));
+        assert!(ProposalMode::Council.is_allowed(&[accounts(2)]));
+        assert!(!ProposalMode::Accounts(vec![accounts(0)]).is_allowed(&[accounts(2)]));
+        assert!(ProposalMode::Accounts(vec![accounts(2)]).is_allowed(&[]));
+        assert!(ProposalMode::Pattern("ch.*".to_string()).is_allowed(&[]));
+        assert!(!ProposalMode::Pattern("b.*".to_string()).is_allowed(&[]));
     }
 }


### PR DESCRIPTION
This allows to switch DAO to only Council, specific accounts or even Regex pattern match can add proposals.